### PR TITLE
Remove 'CN' library and required brackets around `form.result`

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,14 +182,12 @@ let make = () => {
         )
       }
     />
-    {switch (Email->form.result) {
-     | Some(Error(message)) =>
-       <div className={Cn.make(["form-message", "failure"])}>
-         message->React.string
-       </div>
-     | Some(Ok(Valid | NoValue))
-     | None => React.null
-     }}
+    {switch (Email->(form.result)) {
+      | Some(Error(message)) =>
+        <div className="failure"> message->React.string </div>
+      | Some(Ok(Valid | NoValue))
+      | None => React.null
+      }}
     <input
       value={form.state.password}
       disabled={form.submitting}
@@ -204,14 +202,12 @@ let make = () => {
         )
       }
     />
-    {switch (Password->form.result) {
-     | Some(Error(message)) =>
-       <div className={Cn.make(["form-message", "failure"])}>
-         message->React.string
-       </div>
-     | Some(Ok(Valid | NoValue))
-     | None => React.null
-     }}
+    {switch (Password->(form.result)) {
+      | Some(Error(message)) =>
+        <div className="failure"> message->React.string </div>
+      | Some(Ok(Valid | NoValue))
+      | None => React.null
+      }}
     <button disabled={form.submitting}>
       (form.submitting ? "Submitting..." : "Submit")->React.string
     </button>


### PR DESCRIPTION
When I copied the quickstart example you provide into my code I received a number of errors that I needed to fix before I could test the library. These were my small fixes.

The CN library is external, so it shouldn't be included in the 'quickstart' example.
The brackets around `form.result` are required to avoid syntax errors.